### PR TITLE
[fix] 비슷한 콘텐츠 리스트 swiper 갯수 6 -> 5.5로 수정.

### DIFF
--- a/src/components/contents/ReList.jsx
+++ b/src/components/contents/ReList.jsx
@@ -21,7 +21,7 @@ const ReList = ({ recommendData, loading, contentType, contentRating }) => {
                     breakpoints={{
                         599: { slidesPerView: 2, spaceBetween: 10 },
                         600: { slidesPerView: 3, spaceBetween: 20 },
-                        1025: { slidesPerView: 6, spaceBetween: 30 },
+                        1025: { slidesPerView: 5.5, spaceBetween: 30 },
                     }}
                     pagination={{ clickable: true }}
                     className='mySwiper'


### PR DESCRIPTION
[[fix] 비슷한 콘텐츠 리스트 swiper 갯수 6 -> 5.5로 수정.](https://github.com/peaceRyun/vibo/commit/5fe3762b06a3ce20144be13152f2da4c61fac0b8)